### PR TITLE
Refine logout.

### DIFF
--- a/LandmarksAPI/Controllers/UsersController.cs
+++ b/LandmarksAPI/Controllers/UsersController.cs
@@ -35,9 +35,13 @@ namespace LandmarksAPI.Controllers
 
 		[Helpers.Authorize]
 		[HttpPost("logout")]
-		public async System.Threading.Tasks.Task<IActionResult> LogoutAsync()
+		public async System.Threading.Tasks.Task<IActionResult> LogoutAsync(RevokeTokenRequest model)
 		{
-			string response = await _userService.LogoutAsync(AccountContext.Id);
+			var token = model.Token ?? Request.Cookies["refreshToken"];
+			if (string.IsNullOrEmpty(token))
+				return BadRequest(new { message = "Token is required" });
+
+			string response = await _userService.LogoutAsync(AccountContext.Id, token, IpAddress());
 
 			deleteTokenCookie();
 			return Ok(response);

--- a/LandmarksAPI/Models/Users/RevokeTokenRequest.cs
+++ b/LandmarksAPI/Models/Users/RevokeTokenRequest.cs
@@ -1,0 +1,7 @@
+﻿namespace LandmarksAPI.Models.Users
+{
+	public class RevokeTokenRequest
+	{
+		public string Token { get; set; }
+	}
+}

--- a/LandmarksAPI/Services/User/IUserService.cs
+++ b/LandmarksAPI/Services/User/IUserService.cs
@@ -9,7 +9,7 @@ namespace LandmarksAPI.Services.User
 	public interface IUserService
 	{
         Task<AuthenticateResponse> AuthenticateAsync(AuthenticateRequest model, string ipAddress);
-        Task<string> LogoutAsync(string userId);
+        Task<string> LogoutAsync(string userId, string token, string ipAddress);
         IEnumerable<Entities.User> GetAll();
         Task<Account> GetById(string id);
         Task<IActionResult> RegisterAsync(RegisterRequest model, string origin);


### PR DESCRIPTION
Only revoke the token used in the logout request. User might be logged in in other devices with the other tokens.
Committed to the wrong branch, so I'm just going to go with it.